### PR TITLE
Pj/easier to test

### DIFF
--- a/examples/FreeRam/FreeRam.ino
+++ b/examples/FreeRam/FreeRam.ino
@@ -3,6 +3,7 @@
 void setup() 
 {
     Serial.begin(115200);
+    Serial.println(F( "Running " __FILE__ ", Built " __DATE__));
     Serial.println(F("Starting state of the memory:"));
     Serial.println();
     
@@ -17,9 +18,14 @@ void setup()
     Serial.println();
    
     FREERAM_PRINT;
+ 
+    //byte *p = new byte[3000];
+    byte *p = new byte[300];  // Uno (ATmega328) only has 2k RAM
 
-    byte *p = new byte[3000];    
-    
+    if(!p) {
+        Serial.println(F("could not allocate bytes for p[] array!"));
+    }
+        
     Serial.println();
     Serial.println();
     
@@ -37,6 +43,9 @@ void setup()
     Serial.println();
     
     FREERAM_PRINT;
+
+    delete p;
+    p = 0;
 }
 
 void loop() 

--- a/examples/FreeRam/FreeRam.ino
+++ b/examples/FreeRam/FreeRam.ino
@@ -3,6 +3,7 @@
 void setup() 
 {
     Serial.begin(115200);
+    Serial.println(F( "Running " __FILE__ ", Built " __DATE__));
     Serial.println(F("Starting state of the memory:"));
     Serial.println();
     
@@ -37,9 +38,13 @@ void setup()
     Serial.println();
     
     FREERAM_PRINT;
+
+    Serial.print(F("num STACK_COMPUTE calls: "));
+    Serial.println(numStackComputeCalls);
 }
 
 void loop() 
 {
 
 }
+

--- a/examples/FreeRam/FreeRam.ino
+++ b/examples/FreeRam/FreeRam.ino
@@ -1,5 +1,17 @@
 #include <MemoryUsage.h>
 
+byte * p = 0;
+
+
+int updateStack(void)
+{
+    char volatile stuff[] = "updating stack!";
+    stuff[0] = 'U';
+    Serial.println((char *) stuff);
+    FREERAM_PRINT
+    return MU::getFreeRam();
+}
+
 void setup() 
 {
     Serial.begin(115200);
@@ -14,12 +26,19 @@ void setup()
     MEMORY_PRINT_END
     MEMORY_PRINT_HEAPSIZE
 
+    updateStack();
+    
     Serial.println();
     Serial.println();
    
     FREERAM_PRINT;
 
-    byte *p = new byte[3000];    
+    //byte *p = new byte[3000];
+    byte *p = new byte[300];  // Uno (ATmega328) only has 2k RAM
+
+    if(!p) {
+        Serial.println(F("could not allocate bytes for p[] array!"));
+    }
     
     Serial.println();
     Serial.println();
@@ -41,10 +60,12 @@ void setup()
 
     Serial.print(F("num STACK_COMPUTE calls: "));
     Serial.println(numStackComputeCalls);
+
+    delete p;
+    p = 0;
 }
 
 void loop() 
 {
 
 }
-

--- a/examples/GetMemorySize/GetMemorySize.ino
+++ b/examples/GetMemorySize/GetMemorySize.ino
@@ -1,0 +1,53 @@
+#include <MemoryUsage.h>
+
+// Simple example to report memory sizes
+
+void reportAllocation(int numBytes) {
+
+    Serial.print(F("Allocating for "));
+    Serial.print( numBytes );
+    Serial.print(F(" bytes; "));
+    
+    byte *p = new byte[numBytes];
+
+    if (p) {
+        Serial.println(F("...success."));
+    } else {
+        Serial.println(F("...allocation FAILED"));
+    }
+
+    MEMORY_PRINT_HEAPSIZE
+    FREERAM_PRINT
+
+    Serial.println(F("\ndeleting byte array with delete"));
+    delete p;   // don't want a memory leak!
+    p = 0;      // don't want a dangling/obsolete pointer
+
+    MEMORY_PRINT_HEAPSIZE
+    FREERAM_PRINT
+}
+
+void setup() {
+    Serial.begin(115200);
+    delay(1000);
+    Serial.println(F( "Running " __FILE__ ", Built " __DATE__));
+
+    Serial.println(F("\nStarting conditions"));
+    MEMORY_PRINT_TOTALSIZE
+    MEMORY_PRINT_HEAPSIZE
+    FREERAM_PRINT
+
+    Serial.println(F("\nallocate a byte array with new; too big to fit in RAM?"));
+    reportAllocation(3000);
+
+    Serial.println(F("\nallocate smaller byte array with new (it should fit)"));
+    reportAllocation(300);
+
+    Serial.println(F("\nFinal conditions"));
+    MEMORY_PRINT_HEAPSIZE
+    FREERAM_PRINT
+}
+
+void loop() {
+    // User reads output from setup().
+}

--- a/examples/Stack/Stack.ino
+++ b/examples/Stack/Stack.ino
@@ -53,14 +53,6 @@ void setup()
     Serial.println();
     
     reportMemoryInfo();
-    //MEMORY_PRINT_START
-    //MEMORY_PRINT_HEAPSTART
-    //MEMORY_PRINT_HEAPEND
-    //MEMORY_PRINT_STACKSTART
-    //MEMORY_PRINT_END
-    //MEMORY_PRINT_STACKSIZE
-
-    //STACKPAINT_PRINT
 
     Serial.println();
     Serial.println();
@@ -99,12 +91,6 @@ void setup()
     Serial.println();
     
     reportMemoryInfo();
-    //MEMORY_PRINT_START
-    //MEMORY_PRINT_HEAPSTART
-    //MEMORY_PRINT_HEAPEND
-    //MEMORY_PRINT_STACKSTART
-    //MEMORY_PRINT_END
-    //MEMORY_PRINT_STACKSIZE
 
     Serial.print(F("num STACK_COMPUTE calls: "));
     Serial.println(numStackComputeCalls);
@@ -118,10 +104,6 @@ void subFull(rhaaa aSample)
     Serial.println("subFull");
     Serial.println(aSample.text);
     reportMemoryInfo();
-    //MEMORY_PRINT_STACKSTART
-    //MEMORY_PRINT_END
-    //MEMORY_PRINT_STACKSIZE
-    //STACK_PRINT
     Serial.println();
 }
 
@@ -130,10 +112,6 @@ void subPointer(rhaaa *apSample)
     Serial.println("subPointer");
     Serial.println(apSample->text);
     reportMemoryInfo();
-    //MEMORY_PRINT_STACKSTART
-    //MEMORY_PRINT_END
-    //MEMORY_PRINT_STACKSIZE
-    //STACK_PRINT
     Serial.println();
 }
 
@@ -142,10 +120,6 @@ void subSmartPointer(rhaaa &aSample)
     Serial.println("subSmartPointer");
     Serial.println(aSample.text);
     reportMemoryInfo();
-    //MEMORY_PRINT_STACKSTART
-    //MEMORY_PRINT_END
-    //MEMORY_PRINT_STACKSIZE
-    //STACK_PRINT
     Serial.println();
 }
 
@@ -154,10 +128,6 @@ void subConstSmartPointer(const rhaaa &aSample)
     Serial.println("subConstSmartPointer");
     Serial.println(aSample.text);
     reportMemoryInfo();
-    //MEMORY_PRINT_STACKSTART
-    //MEMORY_PRINT_END
-    //MEMORY_PRINT_STACKSIZE
-    //STACK_PRINT
     Serial.println();
 }
 
@@ -172,10 +142,6 @@ void subLocalData()
     
     Serial.println(v[10]);
     reportMemoryInfo();
-    //MEMORY_PRINT_STACKSTART
-    //MEMORY_PRINT_END
-    //MEMORY_PRINT_STACKSIZE
-    //STACK_PRINT
     Serial.println();
 }
 

--- a/examples/Stack/Stack.ino
+++ b/examples/Stack/Stack.ino
@@ -15,9 +15,30 @@ void subPointer(rhaaa *apSample);
 void subSmartPointer(rhaaa &aSample);
 void subConstSmartPointer(const rhaaa &aSample);
 
+inline void reportMemoryInfo(void)
+{
+    STACK_COMPUTE
+
+    MEMORY_PRINT_START
+    MEMORY_PRINT_HEAPSTART
+    MEMORY_PRINT_HEAPEND
+    MEMORY_PRINT_STACKSTART
+    MEMORY_PRINT_END
+    MEMORY_PRINT_STACKSIZE
+
+    STACK_PRINT
+
+    STACKPAINT_PRINT
+    Serial.println();
+}
+
 void setup() 
 {
     Serial.begin(115200);
+    Serial.println(F( "Running " __FILE__ ", Built " __DATE__));
+
+    reportMemoryInfo();
+    //STACK_COMPUTE
     
     // An instance of the sample is declared, and the string is filled with
     // some string to see how to access to it inside functions !
@@ -31,14 +52,15 @@ void setup()
     Serial.println(F("Starting state of the memory:"));
     Serial.println();
     
-    MEMORY_PRINT_START
-    MEMORY_PRINT_HEAPSTART
-    MEMORY_PRINT_HEAPEND
-    MEMORY_PRINT_STACKSTART
-    MEMORY_PRINT_END
-    MEMORY_PRINT_STACKSIZE
+    reportMemoryInfo();
+    //MEMORY_PRINT_START
+    //MEMORY_PRINT_HEAPSTART
+    //MEMORY_PRINT_HEAPEND
+    //MEMORY_PRINT_STACKSTART
+    //MEMORY_PRINT_END
+    //MEMORY_PRINT_STACKSIZE
 
-    STACKPAINT_PRINT
+    //STACKPAINT_PRINT
 
     Serial.println();
     Serial.println();
@@ -68,7 +90,7 @@ void setup()
     // No data as argument, nut a nig array of doubles inside the function...
     subLocalData();
    
-    STACKPAINT_PRINT
+    //STACKPAINT_PRINT
 
     Serial.println();
     Serial.println();
@@ -76,12 +98,16 @@ void setup()
     Serial.println(F("Ending state of the memory:"));
     Serial.println();
     
-    MEMORY_PRINT_START
-    MEMORY_PRINT_HEAPSTART
-    MEMORY_PRINT_HEAPEND
-    MEMORY_PRINT_STACKSTART
-    MEMORY_PRINT_END
-    MEMORY_PRINT_STACKSIZE
+    reportMemoryInfo();
+    //MEMORY_PRINT_START
+    //MEMORY_PRINT_HEAPSTART
+    //MEMORY_PRINT_HEAPEND
+    //MEMORY_PRINT_STACKSTART
+    //MEMORY_PRINT_END
+    //MEMORY_PRINT_STACKSIZE
+
+    Serial.print(F("num STACK_COMPUTE calls: "));
+    Serial.println(numStackComputeCalls);
 
     Serial.println();
     Serial.println();
@@ -91,10 +117,11 @@ void subFull(rhaaa aSample)
 {
     Serial.println("subFull");
     Serial.println(aSample.text);
-    MEMORY_PRINT_STACKSTART
-    MEMORY_PRINT_END
-    MEMORY_PRINT_STACKSIZE
-    STACK_PRINT
+    reportMemoryInfo();
+    //MEMORY_PRINT_STACKSTART
+    //MEMORY_PRINT_END
+    //MEMORY_PRINT_STACKSIZE
+    //STACK_PRINT
     Serial.println();
 }
 
@@ -102,10 +129,11 @@ void subPointer(rhaaa *apSample)
 {
     Serial.println("subPointer");
     Serial.println(apSample->text);
-    MEMORY_PRINT_STACKSTART
-    MEMORY_PRINT_END
-    MEMORY_PRINT_STACKSIZE
-    STACK_PRINT
+    reportMemoryInfo();
+    //MEMORY_PRINT_STACKSTART
+    //MEMORY_PRINT_END
+    //MEMORY_PRINT_STACKSIZE
+    //STACK_PRINT
     Serial.println();
 }
 
@@ -113,10 +141,11 @@ void subSmartPointer(rhaaa &aSample)
 {
     Serial.println("subSmartPointer");
     Serial.println(aSample.text);
-    MEMORY_PRINT_STACKSTART
-    MEMORY_PRINT_END
-    MEMORY_PRINT_STACKSIZE
-    STACK_PRINT
+    reportMemoryInfo();
+    //MEMORY_PRINT_STACKSTART
+    //MEMORY_PRINT_END
+    //MEMORY_PRINT_STACKSIZE
+    //STACK_PRINT
     Serial.println();
 }
 
@@ -124,10 +153,11 @@ void subConstSmartPointer(const rhaaa &aSample)
 {
     Serial.println("subConstSmartPointer");
     Serial.println(aSample.text);
-    MEMORY_PRINT_STACKSTART
-    MEMORY_PRINT_END
-    MEMORY_PRINT_STACKSIZE
-    STACK_PRINT
+    reportMemoryInfo();
+    //MEMORY_PRINT_STACKSTART
+    //MEMORY_PRINT_END
+    //MEMORY_PRINT_STACKSIZE
+    //STACK_PRINT
     Serial.println();
 }
 
@@ -141,10 +171,11 @@ void subLocalData()
         v[i] = (double)i;
     
     Serial.println(v[10]);
-    MEMORY_PRINT_STACKSTART
-    MEMORY_PRINT_END
-    MEMORY_PRINT_STACKSIZE
-    STACK_PRINT
+    reportMemoryInfo();
+    //MEMORY_PRINT_STACKSTART
+    //MEMORY_PRINT_END
+    //MEMORY_PRINT_STACKSIZE
+    //STACK_PRINT
     Serial.println();
 }
 
@@ -152,3 +183,4 @@ void loop()
 {
 
 }
+

--- a/extras/tests/MemoryUsageTest/MemoryUsageTest.ino
+++ b/extras/tests/MemoryUsageTest/MemoryUsageTest.ino
@@ -1,0 +1,246 @@
+// MemoryUsageTest.ino
+//
+// Memory Usage unit tests.  Expected to run on Arduino UNO (ATMega328)
+// (tests may fail on other boards)
+//
+// REQUIRES: MemoryUsage, AUnit libraries.
+//
+#include <MemoryUsage.h>
+
+#include <AUnit.h>
+using namespace MU;
+
+STACK_DECLARE
+
+///////////////////////////////////////////////////////////////
+test(heapStart) {
+    int heapStart = getHeapStart();
+    int dataStart = getDataStart();
+    int memoryEnd = getMemoryEnd();
+    int approxGlobalSize = 350;
+    assertMore(heapStart, dataStart + approxGlobalSize);   // heap after globals
+    assertLess(heapStart, memoryEnd);
+    //assertEqual(908,heapStart);    // too specific! why this value?
+}
+
+///////////////////////////////////////////////////////////////
+test(heapEnd) {
+    int heapEnd = getHeapEnd();
+    int heapStart = getHeapStart();
+    int memoryEnd = getMemoryEnd();
+
+    assertMoreOrEqual(heapEnd, heapStart);
+    assertLess(heapEnd, memoryEnd);
+
+    int reasonableStack = 100;
+    assertLess(heapEnd, (memoryEnd - reasonableStack));
+    //assertEqual(912,he);    // too specific! why this?
+
+    {
+        String foo(F("this is something to put on the heap"));
+        int heapWithString = getHeapEnd();
+        assertMore(heapWithString, heapEnd);
+        assertEqual(39, heapWithString - heapEnd);  // too specific?
+        // foo goes out of scope (and cleaned up)
+    }
+    int heapAfterStringGone = getHeapEnd();
+    assertEqual(heapEnd, heapAfterStringGone);
+}
+
+///////////////////////////////////////////////////////////////
+test(heapSize) {
+    int heapSize = getHeapSize();
+    assertEqual(0, heapSize);
+
+    {
+        String foo(F("this is something to put on the heap"));
+        int heapWithString = getHeapSize();
+        assertMore(heapWithString, heapSize);
+        assertEqual(39, heapWithString - heapSize);  // too specific?
+        // foo goes out of scope (and cleaned up)
+    }
+    int finalHeapSize = getHeapSize();
+    assertEqual(heapSize, finalHeapSize);
+}
+
+///////////////////////////////////////////////////////////////
+test(stackSize) {
+    int ss = getStackSize();
+    assertEqual(12, ss);    // too specific?
+}
+
+///////////////////////////////////////////////////////////////
+void  __attribute__ ((noinline)) STACK_COMPUTE_function(void)
+{
+    // treat this as a real function to ensure stack is up-to-date
+    STACK_COMPUTE;
+}
+
+///////////////////////////////////////////////////////////////
+void  __attribute__ ((noinline)) BIG_STACK_COMPUTE_function(void)
+{
+    // noinline:
+    // treat this is a real function to exersise return stack
+    // do not optimize the function call/return away!
+
+    // volatile:
+    // make this variable ready to change from outside this call chain
+    // do not optimize the data away because it doesn't seem to be used!
+    //
+    char volatile foo[] = "something on the stack";
+    String moreStuff = (char *) foo; // on the heap too
+
+    STACK_COMPUTE_function();
+}
+
+///////////////////////////////////////////////////////////////
+test(stackMaxSize) {
+    int stackSize1 = getMaxStackSize();
+    assertEqual(2, stackSize1);
+
+    STACK_COMPUTE_function(); // first call to STACK_COMPUTE in this sketch
+    int stackSize2 = getMaxStackSize();
+    assertMore(stackSize2, stackSize1);
+
+    int stackSize3 = 0;
+
+    BIG_STACK_COMPUTE_function();
+    stackSize3 = getMaxStackSize();
+    assertMore(stackSize3, stackSize2);
+    assertEqual(stackSize2 + 37, stackSize3); // too specific?
+
+    STACK_COMPUTE_function();
+    int stackSize4 = getMaxStackSize();
+    assertEqual(stackSize3, stackSize4);    // no shrinking
+}
+
+///////////////////////////////////////////////////////////////
+int __attribute__ ((noinline)) exerciseStack(void) {
+    return getStackStart();
+}
+
+///////////////////////////////////////////////////////////////
+int __attribute__ ((noinline)) useMoreFreeRAM(void) {
+    const int numFoos = 100;
+    int volatile foo[numFoos] = {0}; // use stack -- don't optimize away
+    for (int i = 0; i < numFoos; i++) {
+        foo[i] = getFreeRam();
+    }
+    foo[numFoos - 1] = getFreeRam();
+    return foo[numFoos - 1];
+}
+
+///////////////////////////////////////////////////////////////
+test(freeRam) {
+    int frBefore = getFreeRam();
+    assertMore(frBefore, 100);
+    assertLess(frBefore, (int) getRamSize());
+
+    //int currentStack = exerciseStack();
+    exerciseStack();
+    frBefore = getFreeRam();
+    assertMore(frBefore, 100);
+    assertLess(frBefore, (int) getRamSize());
+
+    int frAfter = useMoreFreeRAM();
+
+    assertLess(frAfter, frBefore);
+    int deltaBytes = frAfter - frBefore;
+    assertEqual(deltaBytes, -208); // too specific?
+}
+
+///////////////////////////////////////////////////////////////
+test(ramSize) {
+    int ramSize = getRamSize();
+    assertEqual(2048, ramSize); // for ATmega328
+}
+
+///////////////////////////////////////////////////////////////
+test(dataStart) {
+    int ds = getDataStart();
+    assertEqual(0x100, ds); // for ATmega328
+}
+
+///////////////////////////////////////////////////////////////
+test(memoryEnd) {
+    int me = getMemoryEnd();
+    
+    // NOTE memory end is the last byte of RAM
+    // -- not the byte after
+    int expectedLength = 2048-1; // 2047
+    
+    assertEqual(0x100 + expectedLength, me); // for ATmega328
+}
+
+///////////////////////////////////////////////////////////////
+int __attribute__ ((noinline)) exerciseStackBigger(void) {
+    const int numFoos = 100;
+    int volatile foo[numFoos] = {0};
+    for (int i = 0; i < numFoos; i++) {
+        foo[i] = exerciseStack();
+    }
+    foo[0] = exerciseStack();
+    return foo[0];
+}
+
+///////////////////////////////////////////////////////////////
+test(stackStart) {
+    int stackStart = getStackStart();
+    int ds = getDataStart();
+    int me = getMemoryEnd();
+    assertMore(stackStart, ds + 350);   // should be after globals
+    assertLess(stackStart, me);
+    assertMore(stackStart, me - 50); // stack should not be very big here
+
+    int moreStack = exerciseStackBigger(); // stack grows DOWN
+
+    assertLess(moreStack, stackStart);
+    assertMore(moreStack, stackStart - 230);
+
+    assertEqual(moreStack, stackStart - 210); // too specific?
+}
+
+///////////////////////////////////////////////////////////////
+test(stackWithTop) {
+    char top = '!'; // top of stack
+    int stackStart = (int) &top;
+    int moreStack;  // why aren't these ints taking up room? register vars?
+    {
+        char top2 = '!';
+        moreStack = (int) &top2;
+    }
+    int stackChange = stackStart - moreStack; // stack grows DOWN
+    assertEqual((int) sizeof(char), stackChange);
+}
+
+///////////////////////////////////////////////////////////////
+test(stack_SP_vsTop) {
+    int stackStart;
+    int stackStartSP;
+    char top = '!'; // top of stack (used)
+    stackStart = (int) (&top);
+    stackStartSP = getStackStart(); // next (unused) byte
+
+    assertEqual(stackStartSP + 1, stackStart);
+}
+
+//----------------------------------------------------------------------------
+// setup() and loop()
+//----------------------------------------------------------------------------
+
+void setup() {
+    delay(1000); // wait for stability on some boards to prevent garbage Serial
+    Serial.begin(115200);
+    while (!Serial); // for the Arduino Leonardo/Micro only
+
+    Serial.println(F( "Running " __FILE__ ", Built " __DATE__));
+    Serial.println(F("This test should produce the following:"));
+    Serial.println(
+        F("12 passed, 0 failed, 0 skipped, 0 timed out, out of 12 test(s).")
+    );
+    Serial.println(F("----"));
+}
+
+void loop() {
+    aunit::TestRunner::run();
+}

--- a/src/MemoryUsage.cpp
+++ b/src/MemoryUsage.cpp
@@ -94,23 +94,23 @@ void SRamDisplay(void)
 	
 	available	-=	data_size + bss_size + heap_size + stack_size;
 
-	Serial.print(F("+----------------+ "));			Serial.print((int)&__data_start);	Serial.println(" (__data_start)");
+	Serial.print(F("+----------------+ "));			Serial.print((int)&__data_start);	Serial.println(F(" (__data_start)"));
 	Serial.print(F("+      data      +"));			Serial.println();
 	Serial.print(F("+    variables   + size = "));	Serial.println(data_size);
-	Serial.print(F("+----------------+ "));			Serial.print((int)&__data_end);		Serial.println(" (__data_end / __bss_start)");
+	Serial.print(F("+----------------+ "));			Serial.print((int)&__data_end);		Serial.println(F(" (__data_end / __bss_start)"));
 	Serial.print(F("+      bss       +"));			Serial.println();
 	Serial.print(F("+    variables   + size = "));	Serial.println(bss_size);
-	Serial.print(F("+----------------+ "));			Serial.print((int)&__bss_end);		Serial.println(" (__bss_end / __heap_start)");
+	Serial.print(F("+----------------+ "));			Serial.print((int)&__bss_end);		Serial.println(F(" (__bss_end / __heap_start)"));
 	Serial.print(F("+      heap      + size = "));	Serial.println(heap_size);
-	Serial.print(F("+----------------+ "));			Serial.print((int)heap_end);		Serial.println(" (__brkval if not 0, or __heap_start)");
+	Serial.print(F("+----------------+ "));			Serial.print((int)heap_end);		Serial.println(F(" (__brkval if not 0, or __heap_start)"));
 	Serial.print(F("+                +"));			Serial.println();
 	Serial.print(F("+                +"));			Serial.println();
 	Serial.print(F("+   FREE RAM     + size = "));	Serial.println(available);
 	Serial.print(F("+                +"));			Serial.println();
 	Serial.print(F("+                +"));			Serial.println();
-	Serial.print(F("+----------------+ "));			Serial.print((int)SP);		Serial.println(" (SP)");
+	Serial.print(F("+----------------+ "));			Serial.print((int)SP);		Serial.println(F(" (SP)"));
 	Serial.print(F("+     stack      + size = "));	Serial.println(stack_size);
-	Serial.print(F("+----------------+ "));			Serial.print((int)RAMEND);		Serial.println(" (RAMEND / __stack)");
+	Serial.print(F("+----------------+ "));			Serial.print((int)RAMEND);		Serial.println(F(" (RAMEND / __stack)"));
 
 	Serial.println();
 	Serial.println();

--- a/src/MemoryUsage.cpp
+++ b/src/MemoryUsage.cpp
@@ -75,7 +75,7 @@ uint16_t mu_StackCount(void)
 {
 	uint8_t *p = (__brkval == 0 ? (uint8_t *) &__heap_start : __brkval);
 
-	while (*p == STACK_CANARY && (int) p <= SP)
+	while (*p == STACK_CANARY &&  p <= (uint8_t *) SP)
 		p++;
 
 	return (uint16_t)RAMEND - (uint16_t)p;

--- a/src/MemoryUsage.cpp
+++ b/src/MemoryUsage.cpp
@@ -68,6 +68,8 @@ void mu_StackPaint(void)
 #endif
 }
 
+int numStackComputeCalls = 0;
+
 /// Checks the first undecorated byte.
 uint16_t mu_StackCount(void)
 {

--- a/src/MemoryUsage.h
+++ b/src/MemoryUsage.h
@@ -136,7 +136,7 @@ extern uint8_t *__bss_end;
 /// Print free ram size on serial console.
 #define MEMORY_PRINT_FREERAM	{ Serial.print(F("Free ram:")); Serial.println((int) SP - (int) (__brkval == 0 ? (int)&__heap_start : (int)__brkval)); }
 /// Print total SRAM size on serial console.
-#define MEMORY_PRINT_TOTALSIZE	{ Serial.print(F("SRAM size:")); Serial.println((int) RAMEND - (int) &__data_start); }
+#define MEMORY_PRINT_TOTALSIZE	{ Serial.print(F("SRAM size:")); Serial.println(((int) RAMEND + 1 - (int) &__data_start)); }
 
 /// Displays the 'map' of the current state of the Arduino's SRAM memory on the Serial console.
 void SRamDisplay(void);


### PR DESCRIPTION
This is for a backwards-compatible enhancement to the MemoryUsage library.

At this time MemoryUsage is basically a set of macros to collect usage information as text through Serial.print().

I would like to have more direct access to the numerical values.  This gives me more flexibility in using the values.  With these changes:
- Duplicate code (such as `(__brkval == 0 ? (int)&__heap_start : (int)__brkval)` to get heap end for `MEMORY_PRINT_HEAPEND` and `MEMORY_PRINT_HEAPSIZE`) is gathered into single (inline) functions.  This helps ensure all code using that value will calculate it the same way.
- A sketch can print values in decimal or hex (or both)
- A sketch can customize the output text
- A sketch can send output to somewhere other than Serial
- A sketch can do more than just print the information collected.  For example a sketch could safely restart itself if it detected a memory leak.

This pull request includes https://github.com/Locoduino/MemoryUsage/pull/4 , so if you want both PRs, you only need to review/approve this one.